### PR TITLE
Repaired NuGet packages not downloading correctly

### DIFF
--- a/SeleniumFirst/packages.config
+++ b/SeleniumFirst/packages.config
@@ -3,7 +3,7 @@
   <package id="NUnit" version="3.7.1" targetFramework="net452" />
   <package id="NUnit.ConsoleRunner" version="3.6.1" targetFramework="net452" />
   <package id="NUnit.Extension.NUnitProjectLoader" version="3.5.0" targetFramework="net452" />
-  <package id="NUnit.Extension.NUnitV2PropertiesCollection.driver" version="3.6.0" targetFramework="net452" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.6.0" targetFramework="net452" />
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.5.0" targetFramework="net452" />
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net452" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.5.0" targetFramework="net452" />
@@ -11,7 +11,7 @@
   <package id="NUnit3TestAdapter" version="3.7.0" targetFramework="net452" />
   <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net452" />
   <package id="Selenium.Support" version="3.4.0" targetFramework="net452" />
-  <package id="Selenium.WebPropertiesCollection.driver" version="3.4.0" targetFramework="net452" />
-  <package id="Selenium.WebPropertiesCollection.driver.ChromePropertiesCollection.driver" version="2.30.0.1" targetFramework="net452" />
-  <package id="WebPropertiesCollection.driver.ChromePropertiesCollection.driver.win32" version="2.30.0.0" targetFramework="net452" />
+  <package id="Selenium.WebDriver" version="3.4.0" targetFramework="net452" />
+  <package id="Selenium.WebDriver.ChromeDriver" version="2.30.0.1" targetFramework="net452" />
+  <package id="WebDriver.ChromeDriver.win32" version="2.30.0.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
During the refactoring process there were, accidentally, renamed package names in *packages.config* which resulted in NuGet not being able to download them.

This PR restores the *packages.config* to the previous version, from before the refactoring process.